### PR TITLE
Enabled default OS version, enabled other Service StartupTypes, and set WSearch to automatic.

### DIFF
--- a/2004/ConfigurationFiles/Services.json
+++ b/2004/ConfigurationFiles/Services.json
@@ -151,7 +151,7 @@
   },
   {
     "Name": "WSearch",
-    "VDIState": "Disabled",
+    "VDIState": "Automatic",
     "URL": "https://docs.microsoft.com/en-us/windows/win32/search/-search-3x-wds-overview#windows-search-service",
     "Description": "Windows Search service provides content indexing, property caching, and search results for files, e-mail, and other content."
   },

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A new version of this paper for Windows 10 2004 is pending publication as of 06/
  4. The two folders '2004' and 'LGPO'.
 
 **NOTE:** This script now takes just a few minutes to complete on the reference (gold) device. The total runtime will be presented at the end, in the status output messages.  
-A prompt to reboot will appear when the script has comoletely finished running. Wait for this prompt to confirm the script has successfully completed.  
+A prompt to reboot will appear when the script has finished running. Wait for this prompt to confirm the script has successfully completed.  
 Also, the "-verbose" parameter in PowerShell directs the script to provide descriptive output as the script is running.
 
  ## Full Instructions (for Windows 10 2004, OR Windows 10 1909)


### PR DESCRIPTION
1) Fixed Typos
2) Enabled Windows Version to default to current system's ReleaseID value.
3) Enabled Services to be set to any StartupType.
4) Set WSearch to automatic since Windows 10 multi-session includes per user search indexes.