### PR TITLE
Update Win10_VirtualDesktop_Optimize.ps1

### DIFF
--- a/Win10_VirtualDesktop_Optimize.ps1
+++ b/Win10_VirtualDesktop_Optimize.ps1
@@ -226,7 +226,7 @@ PROCESS {
             If ($UserSettings.Count -gt 0) {
                 Write-Verbose "Processing Default User Settings (Registry Keys)"
 
-                & REG LOAD HKLM\DEFAULT C:\Users\Default\NTUSER.DAT | Out-Null
+                & REG LOAD HKLM\VDOT_TEMP C:\Users\Default\NTUSER.DAT | Out-Null
 
                 Foreach ($Item in $UserSettings) {
                     If ($Item.PropertyType -eq "BINARY") { $Value = [byte[]]($Item.PropertyValue.Split(",")) }


### PR DESCRIPTION
Changing the name given to the default user profile file (NTUSER.DAT), as we load it in regedit during runtime.  Changing it to this:

& REG LOAD HKLM\VDOT_TEMP C:\Users\Default\NTUSER.DAT | Out-Null