### PR TITLE
Added -Type for Set-ItemProperty

### DIFF
--- a/Win10_VirtualDesktop_Optimize.ps1
+++ b/Win10_VirtualDesktop_Optimize.ps1
@@ -302,7 +302,7 @@ PROCESS {
                         If (Get-ItemProperty -Path ("{0}" -f $Item.HivePath) -ErrorAction SilentlyContinue)
                         {
                             Write-EventLog -EventId 40 -Message "Set $($Item.HivePath) - $Value" -LogName 'Virtual Desktop Optimization' -Source 'DefaultUserSettings' -EntryType Information
-                            Set-ItemProperty -Path ("{0}" -f $Item.HivePath) -Name $Item.KeyName -Value $Value -Force 
+                            Set-ItemProperty -Path ("{0}" -f $Item.HivePath) -Name $Item.KeyName -Value $Value -Tyoe $Item.PropertyType -Force
                         }
                         Else
                         {


### PR DESCRIPTION
#region Customize Default User Profile section does not have -Type syntax for (Set-ItemProperty -Path ("{0}" -f $Item.HivePath) -Name $Item.KeyName -Value $Value -Force). Hence, it always sets an item property as a string as default no matter if it is DWORD or Binary. After adding "-Tyoe $Item.PropertyType"  registry keys are set as required.