### PR TITLE
Update Paint 3D entry

### DIFF
--- a/2009/ConfigurationFiles/AppxPackages.json
+++ b/2009/ConfigurationFiles/AppxPackages.json
@@ -56,8 +56,8 @@
   {
     "AppxPackage": "Microsoft.Paint",
     "VDIState": "Unchanged",
-    "URL": "https://www.microsoft.com/en-us/p/paint/9pcfs5b6t72h",
-    "Description": "Windows basic sketching and graphics app"
+    "URL": "https://apps.microsoft.com/store/detail/paint-3d/9NBLGGH5FV99",
+    "Description": "Paint 3D app (not Classic Paint app)"
   },
   {
     "AppxPackage": "Microsoft.People",


### PR DESCRIPTION
The entry for "MSPaint" leads you to believe this is the "Classic" Paint app, which it is not.  Removing the "MSPaint" store app does not remove the Classic paint.  I updated the description and URL for the MSPaint app