### PR TITLE
Error in "Microsoft.MSPaint" Appx block

### DIFF
--- a/2009/ConfigurationFiles/AppxPackages.json
+++ b/2009/ConfigurationFiles/AppxPackages.json
@@ -54,7 +54,7 @@
     "Description": "Note-taking app"
   },
   {
-    "AppxPackage": "Microsoft.Paint",
+    "AppxPackage": "Microsoft.MSPaint",
     "VDIState": "Unchanged",
     "URL": "https://apps.microsoft.com/store/detail/paint-3d/9NBLGGH5FV99",
     "Description": "Paint 3D app (not Classic Paint app)"


### PR DESCRIPTION
We had "Microsoft.Paint".  The app to remove is called "Microsoft.MSPaint".  This is the change I made here.