### PR TITLE
added missing lastRun registry functionality

### DIFF
--- a/Windows_VDOT.ps1
+++ b/Windows_VDOT.ps1
@@ -91,7 +91,7 @@ it is nearly impossible to get it back.  Please review the configuration files a
 #>
 BEGIN 
 {
-    [Version]$VDOTVersion = "2.0.2009.1" 
+    [Version]$VDOTVersion = "2.1.2009.1" 
     # Create Key
     $KeyPath = 'HKLM:\SOFTWARE\VDOT'
     If (-Not(Test-Path $KeyPath))

--- a/Windows_VDOT.ps1
+++ b/Windows_VDOT.ps1
@@ -91,7 +91,7 @@ it is nearly impossible to get it back.  Please review the configuration files a
 #>
 BEGIN 
 {
-    $VDOTVersion = "2.0.2009.1" 
+    [Version]$VDOTVersion = "2.0.2009.1" 
     # Create Key
     $KeyPath = 'HKLM:\SOFTWARE\VDOT'
     If (-Not(Test-Path $KeyPath))
@@ -117,6 +117,10 @@ BEGIN
     If (Get-ItemProperty $KeyPath -Name LastRunTime -ErrorAction SilentlyContinue)
     {
         Set-ItemProperty -Path $KeyPath -Name $LastRun -Value $LastRunValue
+    }
+    Else
+    {
+        New-ItemProperty -Path $KeyPath -Name $LastRun -Value $LastRunValue | Out-Null
     }
 
     If (-not([System.Diagnostics.EventLog]::SourceExists("Virtual Desktop Optimization")))


### PR DESCRIPTION
I found in testing that the Key "LastRun" was not getting set.  The check looked to see if the property was there, and if so update it, but it was never initially set, and thus would never get in the first place.