### PR TITLE
Remove "DiagTrack" block

### DIFF
--- a/2009/ConfigurationFiles/Services.json
+++ b/2009/ConfigurationFiles/Services.json
@@ -22,12 +22,6 @@
     "Description": "Diagnostic Execution Service"
   },
   {
-    "Name": "DiagTrack",
-    "VDIState": "Unchanged",
-    "URL": "https://docs.microsoft.com/en-us/windows/privacy/configure-windows-diagnostic-data-in-your-organization",
-    "Description": "Connected User Experiences and Telemetry service, manages the event driven collection and transmission of diagnostic and usage information (used to improve the experience and quality of the Windows Platform) when the diagnostics and usage privacy option settings are enabled under Feedback and Diagnostics."
-  },
-  {
     "Name": "DPS",
     "VDIState": "Disabled",
     "URL": "https://docs.microsoft.com/en-us/uwp/api/Windows.System.Diagnostics?view=winrt-19041",


### PR DESCRIPTION
Had an issue reported where disabling DiagTrack could be involved.  Removing the "DiagTrack" block of code altogether.