### PR TITLE
Remove "widgets" from Windows

### DIFF
--- a/2009/ConfigurationFiles/PolicyRegSettings.json
+++ b/2009/ConfigurationFiles/PolicyRegSettings.json
@@ -1,5 +1,12 @@
 [
     {
+        "RegItemPath": "HKLM:\\Software\\Policies\\Microsoft\\Dsh",
+        "RegItemValueName": "AllowNewsAndInterests",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "0",
+        "VDIState": "Enabled"
+    },
+        {
         "RegItemPath": "HKLM:\\Software\\Policies\\Microsoft\\Windows\\Windows Feeds",
         "RegItemValueName": "EnableFeeds",
         "RegItemValueType": "DWord",


### PR DESCRIPTION
Disable a setting called "Allow widgets".  This shows news and things on the taskbar...but presumably only when the device can reach the service that provides the data.  These settings manifest as soccer balls, news, stock tickers, or whatnot on the taskbar and in the Search section on the taskbar.  I believe this started with 22H2 in Windows 10.  Also applies to Windows 11.