### PR TITLE
Update "remove OneDrive" code

### DIFF
--- a/Windows_VDOT.ps1
+++ b/Windows_VDOT.ps1
@@ -703,9 +703,8 @@ PROCESS {
                 Start-Process $_ -ArgumentList "/uninstall" -Wait
             }
         }
-        Write-EventLog -EventId 80 -Message "Removing shortcut links for OneDrive" -LogName 'Virtual Desktop Optimization' -Source 'AdvancedOptimizations' -EntryType Information
-        Remove-Item -Path 'C:\Windows\ServiceProfiles\LocalService\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\OneDrive.lnk' -Force -ErrorAction SilentlyContinue
-        Remove-Item -Path 'C:\Windows\ServiceProfiles\NetworkService\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\OneDrive.lnk'  -Force -ErrorAction SilentlyContinue
+        Write-EventLog -EventId 80 -Message "Removing shortcut links and other OneDrive collateral." -LogName 'Virtual Desktop Optimization' -Source 'AdvancedOptimizations' -EntryType Information
+        Get-ChildItem C:\OneDrive.* -ErrorAction SilentlyContinue -Recurse | Remove-Item -Force -ErrorAction SilentlyContinue
     }
 
     #endregion


### PR DESCRIPTION
Addressing an issue where the current VDOT "remove OneDrive" code was run, and it worked as intended.  Yet OneDrive still shows up on the Start menu.  It was not functional of course, but where customers ask for OneDrive to be removed, they don't want it right there on the Start menu.  This code does a more sweeping deletion of OneDrive files. And it's not like you can't get it back if you want it.  You can download the OneDrive installer.