### PR TITLE
Remove the Edge "Search bar" desktop widget

### DIFF
--- a/2009/ConfigurationFiles/EdgeSettings.json
+++ b/2009/ConfigurationFiles/EdgeSettings.json
@@ -62,5 +62,13 @@
         "RegItemValueType": "DWord",
         "RegItemValue": "0",
         "VDIState": "Enabled"
+    },
+    {
+        "Description": "Policy setting to control an Edge search bar that gets placed on the user desktop automatically",
+        "RegItemPath": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge",
+        "RegItemValueName": "WebWidgetAllowed",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "0",
+        "VDIState": "Enabled"
     }
 ]


### PR DESCRIPTION
I installed updates on a Windows 10 image, rebooted, and there is a new "Search bar".  This PR is to take that policy setting to "Off".