### PR TITLE
Added 'Restore' task

### DIFF
--- a/2009/ConfigurationFiles/ScheduledTasks.json
+++ b/2009/ConfigurationFiles/ScheduledTasks.json
@@ -139,5 +139,10 @@
     "ScheduledTask": "Work Folders Maintenance Work",
     "VDIState": "Disabled",
     "Description": "Customer Experience Improvement Program task"
+  },
+  {
+    "ScheduledTask": "Restore",
+    "VDIState": "Unchanged",
+    "Description": "Handles restoring settings from the cloud"
   }
 ]


### PR DESCRIPTION
Added an entry for the 'Restore' task that was added around September 2023. This task most likely would never apply to AVD and never would apply to domain-joined. I left the state at unchanged so individuals can disable it themselves if they so choose.