### PR TITLE
Robert Smith, June 2024 VDOT changes

### DIFF
--- a/2009/ConfigurationFiles/AppxPackages.json
+++ b/2009/ConfigurationFiles/AppxPackages.json
@@ -33,7 +33,7 @@
     "AppxPackage": "Microsoft.DesktopAppInstaller",
     "VDIState": "Unchanged",
     "URL": "https://apps.microsoft.com/detail/9NBLGGH4NNS1",
-    "Description": "Microsoft App Installer for Windows 10 makes sideloading Windows 10 apps easy"
+    "Description": "Microsoft App Installer for Windows 10 makes sideloading Windows apps easy"
   },
   {
     "AppxPackage": "Microsoft.GamingApp",

--- a/2009/ConfigurationFiles/AppxPackages.json
+++ b/2009/ConfigurationFiles/AppxPackages.json
@@ -1,5 +1,11 @@
 [
   {
+    "AppxPackage": "Bing Search",
+    "VDIState": "Unchanged",
+    "URL": "https://apps.microsoft.com/detail/9nzbf4gt040c",
+    "Description": "Web Search from Microsoft Bing provides web results and answers in Windows Search"
+  },
+  {
     "AppxPackage": "Clipchamp.Clipchamp",
     "VDIState": "Unchanged",
     "URL": "https://apps.microsoft.com/detail/9p1j8s7ccwwt?hl=en-us&gl=US",

--- a/2009/ConfigurationFiles/DefaultUserSettings.json
+++ b/2009/ConfigurationFiles/DefaultUserSettings.json
@@ -1,5 +1,166 @@
 [
     {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent",
+        "KeyName": "DisableThirdPartySuggestions",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent",
+        "KeyName": "DisableTailoredExperiencesWithDiagnosticData",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer",
+        "KeyName": "NoResolveSearch",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\Directory UI",
+        "KeyName": "QueryLimit",
+        "PropertyType": "DWord",
+        "PropertyValue": "1500",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\Explorer",
+        "KeyName": "NoWindowMinimizingShortcuts",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer",
+        "KeyName": "TaskbarNoNotification",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent",
+        "KeyName": "DisableWindowsSpotlightFeatures",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer",
+        "KeyName": "NoThumbnailCache",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\Explorer",
+        "KeyName": "DisableSearchBoxSuggestions",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\Explorer",
+        "KeyName": "NoBalloonFeatureAdvertisements",
+        "PropertyType": "DWord",
+        "PropertyValue": "",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Control Panel\\International",
+        "KeyName": "TurnOffOfferTextPredictions",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\Explorer",
+        "KeyName": "DisableThumbsDBOnNetworkFolders",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\CurrentVersion\\PushNotifications",
+        "KeyName": "NoToastApplicationNotification",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\CurrentVersion\\PushNotifications",
+        "KeyName": "NoToastApplicationNotificationOnLockScreen",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\EdgeUI",
+        "KeyName": "DisableMFUTracking",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer",
+        "KeyName": "NoInstrumentation",
+        "PropertyType": "DWord",
+        "PropertyValue": "",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Edge\\Recommended",
+        "KeyName": "StartupBoostEnabled",
+        "PropertyType": "DWord",
+        "PropertyValue": "0",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\EdgeUpdate",
+        "KeyName": "UpdatesSuppressedDurationMin",
+        "PropertyType": "DWord",
+        "PropertyValue": "900",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\EdgeUpdate",
+        "KeyName": "UpdatesSuppressedStartHour",
+        "PropertyType": "DWord",
+        "PropertyValue": "4",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\EdgeUpdate",
+        "KeyName": "UpdatesSuppressedStartMin",
+        "PropertyType": "DWord",
+        "PropertyValue": "0",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer",
+        "KeyName": "NoSearchInternetInStartMenu",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\Explorer",
+        "KeyName": "NoRemoteDestinations",
+        "PropertyType": "DWord",
+        "PropertyValue": "1",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent",
+        "KeyName": "ConfigureWindowsSpotlight",
+        "PropertyType": "DWord",
+        "PropertyValue": "2",
+        "SetProperty": "True"
+    },
+    {
         "HivePath": "HKLM:\\VDOT_TEMP\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer",
         "KeyName": "ShellState",
         "PropertyType": "BINARY",
@@ -236,5 +397,12 @@
         "PropertyType": "DWORD",
         "PropertyValue": 0,
         "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\Software\\SOFTWARE\\Policies\\Microsoft\\Windows\\WindowsCopilot",
+        "KeyName": "TurnOffWindowsCopilot",
+        "PropertyType": "DWORD",
+        "PropertyValue": 1,
+        "SetProperty": "False"
     }
 ]

--- a/2009/ConfigurationFiles/DefaultUserSettings.json
+++ b/2009/ConfigurationFiles/DefaultUserSettings.json
@@ -1,5 +1,12 @@
 [
     {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
+        "KeyName": "TaskbarMn",
+        "PropertyType": "DWord",
+        "PropertyValue": "0",
+        "SetProperty": "True"
+    },
+    {
         "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Policies\\Microsoft\\Windows\\CloudContent",
         "KeyName": "DisableThirdPartySuggestions",
         "PropertyType": "DWord",

--- a/2009/ConfigurationFiles/DefaultUserSettings.json
+++ b/2009/ConfigurationFiles/DefaultUserSettings.json
@@ -1,6 +1,13 @@
 [
     {
         "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
+        "KeyName": "Start_IrisRecommendations",
+        "PropertyType": "DWord",
+        "PropertyValue": "0",
+        "SetProperty": "True"
+    },
+    {
+        "HivePath": "HKLM:\\VDOT_TEMP\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Advanced",
         "KeyName": "TaskbarMn",
         "PropertyType": "DWord",
         "PropertyValue": "0",

--- a/Windows_VDOT.ps1
+++ b/Windows_VDOT.ps1
@@ -52,14 +52,13 @@ Param (
 - AUTHORED BY:    Robert M. Smith and Tim Muessig (Microsoft)
 - AUTHORED DATE:  11/19/2019
 - CONTRIBUTORS:   Travis Roberts (2020), Jason Parker (2020), @brentil (2024)
-- LAST UPDATED:   6/7/2024
-- PURPOSE:        To automatically apply settings referenced in the following white papers:
-                  https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds_vdi-recommendations-1909
+- LAST UPDATED:   6/11/2024
+- PURPOSE:        To automatically apply many optimization settings to and Windows device; VDI, AVD, standalone machine
                   
 - Important:      Every setting in this script and input files are possible optimizations only,
                   and NOT recommendations or requirements. Please evaluate every setting for applicability
                   to your specific environment. These scripts have been tested on Hyper-V VMs, as well as Azure VMs...
-                  including Windows 11.
+                  including Windows 11 23H2.
                   Please test thoroughly in your environment before implementation
 
 - DEPENDENCIES    1. On the target machine, run PowerShell elevated (as administrator)

--- a/Windows_VDOT.ps1
+++ b/Windows_VDOT.ps1
@@ -51,8 +51,8 @@ Param (
 - TITLE:          Microsoft Windows Virtual Desktop Optimization Script
 - AUTHORED BY:    Robert M. Smith and Tim Muessig (Microsoft)
 - AUTHORED DATE:  11/19/2019
-- CONTRIBUTORS:   Travis Roberts (2020), Jason Parker (2020)
-- LAST UPDATED:   7/8/2022
+- CONTRIBUTORS:   Travis Roberts (2020), Jason Parker (2020), @brentil (2024)
+- LAST UPDATED:   6/7/2024
 - PURPOSE:        To automatically apply settings referenced in the following white papers:
                   https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/rds_vdi-recommendations-1909
                   
@@ -756,6 +756,7 @@ PROCESS {
             Write-EventLog -EventId 90 -Message "Clearing BranchCache cache" -LogName 'Virtual Desktop Optimization' -Source 'DiskCleanup' -EntryType Information
             Write-Host "Clearing BranchCache cache" 
             Clear-BCCache -Force -ErrorAction SilentlyContinue
+        
         }    #endregion
 
     Set-Location $CurrentLocation

--- a/Windows_VDOT.ps1
+++ b/Windows_VDOT.ps1
@@ -31,7 +31,7 @@ Param (
     [ArgumentCompleter( { Get-ChildItem $PSScriptRoot -Directory | Select-Object -ExpandProperty Name } )]
     [System.String]$WindowsVersion = (Get-ItemProperty "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\").ReleaseId,
 
-    [ValidateSet('All','WindowsMediaPlayer','AppxPackages','ScheduledTasks','DefaultUserSettings','Autologgers','Services','NetworkOptimizations','DiskCleanup')] 
+    [ValidateSet('All','WindowsMediaPlayer','AppxPackages','ScheduledTasks','DefaultUserSettings','LocalPolicy','Autologgers','Services','NetworkOptimizations','DiskCleanup')] 
     [String[]]
     $Optimizations,
 
@@ -118,7 +118,7 @@ BEGIN
         New-ItemProperty -Path $KeyPath -Name $LastRun -Value $LastRunValue | Out-Null
     }
     
-    $EventSources = @('VDOT', 'WindowsMediaPlayer', 'AppxPackages', 'ScheduledTasks', 'DefaultUserSettings', 'Autologgers', 'Services', 'NetworkOptimizations', 'AdvancedOptimizations', 'DiskCleanup')
+    $EventSources = @('VDOT', 'WindowsMediaPlayer', 'AppxPackages', 'ScheduledTasks', 'DefaultUserSettings', 'Autologgers', 'Services', 'LocalPolicy', 'NetworkOptimizations', 'AdvancedOptimizations', 'DiskCleanup')
     If (-not([System.Diagnostics.EventLog]::SourceExists("Virtual Desktop Optimization")))
     {
         # All VDOT main function Event ID's [1-9]


### PR DESCRIPTION
# June 2024 VDOT changes:

- Updated documentation in .PS1 to update last touched date, and a few minor verbiage changes
- Updated list of apps in '**AppxPackages.json**' with some new Windows 11 apps
- Changed a default user setting called '**IconsOnly**' from true to false, so that it does not apply by default.  This caused at least one icon (Teams) to display with a generic icon when accessed via Search.
- Removed final remnants of references to LGPO.exe, which was deprecated previously.  In doing this, changed "**LGPO**" event log source to "**LocalPolicy**" event log source, to align with how these policy settings are being applied.
- Fixed an issue where some settings were being applied only to local user and not default user profile.  Those settings were mirrored so they apply to both local profile of account being used to run VDOT, and default user profile.