### PR TITLE
Issue201 "DeleteUserAppContainersOnLogoff"

### DIFF
--- a/2009/ConfigurationFiles/PolicyRegSettings.json
+++ b/2009/ConfigurationFiles/PolicyRegSettings.json
@@ -1,5 +1,12 @@
 [
     {
+        "RegItemPath": "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy",
+        "RegItemValueName": "DeleteUserAppContainersOnLogoff",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Enabled"
+    },
+    {
         "RegItemPath": "HKLM:\\Software\\Policies\\Microsoft\\Dsh",
         "RegItemValueName": "AllowNewsAndInterests",
         "RegItemValueType": "DWord",


### PR DESCRIPTION
I suggest adding the registry key "DeleteUserAppContainersOnLogoff" (DWORD, set to 1) to Default Optimization Tool. This key, located at HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\SharedAccess\Parameters\FirewallPolicy, addresses server slowdowns and unresponsiveness caused by the accumulation of excessive Windows firewall rules during multiple user sessions.

This optimization is already recommended by the Citrix Optimizer for similar issues, indicating its effectiveness. For reference, see the Microsoft support article (https://support.microsoft.com/en-gb/topic/march-26-2019-kb4490481-os-build-17763-402-c323e5c1-d524-dbdb-04a0-c3b5c8c8f2fd) and a relevant discussion on Spiceworks(https://community.spiceworks.com/topic/2285411-server2019-rds-hundreds-of-firewall-rules-per-user-per-session).

I'm curious if anyone has tested this in Windows 11 Multi-Session environments and can share their insights or if the problem is less prevalent there.

Thanks for considering this optimization to enhance performance.