### PR TITLE
Added new entry for Teams appx, possible internal app name change

### DIFF
--- a/2009/ConfigurationFiles/AppxPackages.json
+++ b/2009/ConfigurationFiles/AppxPackages.json
@@ -296,7 +296,13 @@
   {
     "AppxPackage": "MicrosoftTeams",
     "VDIState": "Unchanged",
-    "URL": "https://www.microsoft.com/en-us/microsoft-teams/group-chat-software",
+    "URL": "https://apps.microsoft.com/detail/xp8bt8dw290mpq",
+    "Description": "Microsoft communication platform"
+  },
+  {
+    "AppxPackage": "MSTeams",
+    "VDIState": "Unchanged",
+    "URL": "https://apps.microsoft.com/detail/xp8bt8dw290mpq",
     "Description": "Microsoft communication platform"
   },
   {


### PR DESCRIPTION
Testing in Windows 11 24H2 and Teams was still there.  The appx package name is 'MSTeams'.  This change adds a new entry for 'MSTeams'