### PR TITLE
Win11 OOBE enhancements and remove "NotepadPlusPlus" UWP app

### DIFF
--- a/2009/ConfigurationFiles/AppxPackages.json
+++ b/2009/ConfigurationFiles/AppxPackages.json
@@ -1,4 +1,10 @@
 [
+   {
+    "AppxPackage": "NotepadPlusPlus",
+    "VDIState": "Unchanged",
+    "URL": "",
+    "Description": ""
+  },
   {
     "AppxPackage": "Bing Search",
     "VDIState": "Unchanged",

--- a/2009/ConfigurationFiles/PolicyRegSettings.json
+++ b/2009/ConfigurationFiles/PolicyRegSettings.json
@@ -1,45 +1,66 @@
 [
     {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Policies\\Microsoft\\Windows\\Explorer",
+        "RegItemValueName": "HideRecommendedSection",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Unchanged"
+    },
+    {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\PolicyManager\\current\\device\\Start",
+        "RegItemValueName": "HideRecommendedSection",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Unchanged"
+    },
+    {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\PolicyManager\\current\\device\\Education",
+        "RegItemValueName": "IsEducationEnvironment",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Unchanged"
+    },
+    {
         "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
         "RegItemValueName": "HideOOBE",
         "RegItemValueType": "DWord",
         "RegItemValue": "1",
-        "VDIState": "Enabled"
+        "VDIState": "Unchanged"
     },
     {
         "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
         "RegItemValueName": "HideEULAPage",
         "RegItemValueType": "DWord",
         "RegItemValue": "1",
-        "VDIState": "Enabled"
+        "VDIState": "Unchanged"
     },
     {
         "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
         "RegItemValueName": "HideLocalAccountScreen",
         "RegItemValueType": "DWord",
         "RegItemValue": "1",
-        "VDIState": "Enabled"
+        "VDIState": "Unchanged"
     },
     {
         "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
         "RegItemValueName": "HideOEMRegistrationScreen",
         "RegItemValueType": "DWord",
         "RegItemValue": "1",
-        "VDIState": "Enabled"
+        "VDIState": "Unchanged"
     },
     {
         "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
         "RegItemValueName": "HideWirelessSetupInOOBE",
         "RegItemValueType": "DWord",
         "RegItemValue": "1",
-        "VDIState": "Enabled"
+        "VDIState": "Unchanged"
     },
     {
         "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
         "RegItemValueName": "ProtectYourPC",
         "RegItemValueType": "DWord",
         "RegItemValue": "1",
-        "VDIState": "Enabled"
+        "VDIState": "Unchanged"
     },
     {
         "RegItemPath": "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy",

--- a/2009/ConfigurationFiles/PolicyRegSettings.json
+++ b/2009/ConfigurationFiles/PolicyRegSettings.json
@@ -1,5 +1,47 @@
 [
     {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
+        "RegItemValueName": "HideOOBE",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Enabled"
+    },
+    {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
+        "RegItemValueName": "HideEULAPage",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Enabled"
+    },
+    {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
+        "RegItemValueName": "HideLocalAccountScreen",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Enabled"
+    },
+    {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
+        "RegItemValueName": "HideOEMRegistrationScreen",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Enabled"
+    },
+    {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
+        "RegItemValueName": "HideWirelessSetupInOOBE",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Enabled"
+    },
+    {
+        "RegItemPath": "HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\OOBE",
+        "RegItemValueName": "ProtectYourPC",
+        "RegItemValueType": "DWord",
+        "RegItemValue": "1",
+        "VDIState": "Enabled"
+    },
+    {
         "RegItemPath": "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\SharedAccess\\Parameters\\FirewallPolicy",
         "RegItemValueName": "DeleteUserAppContainersOnLogoff",
         "RegItemValueType": "DWord",


### PR DESCRIPTION
Several updates to account for Windows 11 OOBE.  The settings are there, but are set to "unchanged", so if they need to be implemented, change those values to "enabled".
Discovered yet another new UWP app in Windows 11 24H2: "NotepadPlusPlus". That app is version1, I couldn't find it in the Store online, so adding it in case someone else wants to remove it.